### PR TITLE
Allow relative path for library

### DIFF
--- a/aqueduct_addon/ad_gui.py
+++ b/aqueduct_addon/ad_gui.py
@@ -11,8 +11,8 @@ def make_path_absolute(key):
     sane_path = lambda p: os.path.abspath(bpy.path.abspath(p))
 
     # if key in props and props[key].startswith('//'):
-    if key in props:
-        props[key] = sane_path(props[key])
+    ##if key in props:
+    ##    props[key] = sane_path(props[key])
 
 class AD_UL_ListItem(PropertyGroup):
     """ Propertygroup holding info for filelist items """


### PR DESCRIPTION
I keep reusable assets relative to projects so they are portable between systems and safely stored: 

Library: `//../`

Portion of project folder:

```tree
...
MODEL
|-- xxx_mdl_iss.blend
|-- xxx_mdl_iss_2011.md
`-- xxx_mdl_r2_withlegs.blend
SCENE
|-- xxx_sce_iss-bp.adoc
`-- xxx_sce_iss-bp.blend
MATERIAL
|-- xxx_matcap_bp.exr
`-- xxx_sce_matcapgen.blend
...
```